### PR TITLE
Force Jekyll to emit .well-known folder

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+include:
+  - ".well-known"


### PR DESCRIPTION
This should fix the issue you had fixing https://github.com/dweymouth/supersonic/issues/144, where Jekyll wouldn't emit .well-known.

I've added a configuration file that *forces* it to emit the folder.
[For reference, the `include` parameter is explicitly defined in Jekyll's configuration docs.](https://jekyllrb.com/docs/configuration/options/)

Another option is to throw a `.nojekyll` in the root...

Anyway, hope this helps.  Big fan of the project!

freshgum